### PR TITLE
Tidy workflow files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,0 @@
-.*        export-ignore
-*.md      export-ignore
-*.mod     export-ignore
-*.sum     export-ignore
-*.yml     export-ignore
-LICENSE   export-ignore
-*_test.go export-ignore


### PR DESCRIPTION
Для того, чтобы в проектах с зависимостью jsonj в директории vendor не было git-workflow-специфичных файлов.

~~1. Конфиг линтера перенесен в .github/workflow~~
2. Удален .gitattributes, т.к. он исключает файлы только в архиве релиза, но при этом сам попадает в vendor